### PR TITLE
clear screen when playing and opening main menu

### DIFF
--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -145,7 +145,7 @@ _info_select_radio_play() {
   VOTESINFO=$(cat $LIST_PATH 2>/dev/null | jq -r ".[$ANS-1]" | grep "votes\":" | awk -F': ' '{print $2}' | sed 's/"//g' | sed 's/+/ /g' | sed 's/,//g')
   CODECINFO=$(cat $LIST_PATH 2>/dev/null | jq -r ".[$ANS-1]" | grep "codec\":" | awk -F': ' '{print $2}' | sed 's/"//g' | sed 's/+/ /g' | sed 's/,//g')
   BITRATEINFO=$(cat $LIST_PATH 2>/dev/null | jq -r ".[$ANS-1]" | grep "bitrate\":" | awk -F': ' '{print $2}' | sed 's/"//g' | sed 's/+/ /g' | sed 's/,//g')
-  echo
+  clear
   magentaprint "--------- Info Radio: ------------"
   greenprint "NAME: $NAMEINFO"
   blueprint "TAGS: $TAGSINFO"

--- a/tera
+++ b/tera
@@ -87,6 +87,7 @@ if [ ! -f "$FAVORITE_FULL" ]; then
 fi
 
 menu() {
+clear
     printf "%b" "
 $APP_NAME MAIN MENU
 $(greenprint '1)') Play from my list


### PR DESCRIPTION
## 📑 Description
Calls a 'clear' before drawing radio info and main menu, so everything is always at the top of the screen.

- [ ] Not Completed
- [x] Completed

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [X] All the tests have passed