### PR TITLE
feat: use XDG directories for theme config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/go-music-players/xdg-dirs v0.1.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQ
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/go-music-players/xdg-dirs v0.1.0 h1:+Mo+rGIBg+IOgkUtgn8KKuEhbGt0BrMalcPlcOZNzwA=
+github.com/go-music-players/xdg-dirs v0.1.0/go.mod h1:GLqocFqlBnt+0Ek91P3v1BFykZS/pC2rv71K8CceAd8=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/charmbracelet/lipgloss"
+	xdgdirs "github.com/go-music-players/xdg-dirs"
 	"gopkg.in/yaml.v3"
 )
 
@@ -64,22 +65,13 @@ var (
 	mu      sync.RWMutex
 )
 
-// GetConfigDir returns the theme config directory path
-func GetConfigDir() (string, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(homeDir, ".config", "tera"), nil
-}
-
 // GetConfigPath returns the theme config file path
 func GetConfigPath() (string, error) {
-	configDir, err := GetConfigDir()
+	dirs, err := xdgdirs.New("tera")
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(configDir, "theme.yaml"), nil
+	return filepath.Join(dirs.Config, "theme.yaml"), nil
 }
 
 // Load loads the theme from config file, or returns default if not found


### PR DESCRIPTION
Switch from hardcoded `~/.config/tera` to XDG Base Directory specification using go-music-players/xdg-dirs library. This ensures proper config directory placement across different platforms and respects user XDG environment variables.