### PR TITLE
fix(ui): change shuffle hotkey to "ctrl+t"

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ Set a timer to automatically stop playback — useful for falling asleep to radi
 Enter a keyword (genre, mood, style) and TERA finds a random matching station. Perfect for music discovery!
 
 **Shuffle Mode**: Enable shuffle mode to automatically cycle through multiple stations matching your keyword:
-- Press `t` to toggle shuffle on/off
+- Press `ctrl+t` to toggle shuffle on/off
 - Stations play in random order without repeats
 - Optional auto-advance timer (configurable)
 - Navigate backward through recently played stations
@@ -534,7 +534,7 @@ Shuffle mode is an enhanced version of "I Feel Lucky" that lets you explore mult
 ### How It Works
 
 1. Navigate to **I Feel Lucky** from the main menu (option 9)
-2. Press `t` to toggle shuffle mode on
+2. Press `ctrl+t` to toggle shuffle mode on
 3. Enter your keyword (e.g., "jazz", "rock", "meditation")
 4. Press Enter to start shuffle mode
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -361,7 +361,7 @@ Set a timer to automatically stop playback — useful for falling asleep to radi
 Enter a keyword (genre, mood, style) and TERA finds a random matching station. Perfect for music discovery!
 
 **Shuffle Mode**: Enable shuffle mode to automatically cycle through multiple stations matching your keyword:
-- Press `t` to toggle shuffle on/off
+- Press `ctrl+t` to toggle shuffle on/off
 - Stations play in random order without repeats
 - Optional auto-advance timer (configurable)
 - Navigate backward through recently played stations
@@ -534,7 +534,7 @@ Shuffle mode is an enhanced version of "I Feel Lucky" that lets you explore mult
 ### How It Works
 
 1. Navigate to **I Feel Lucky** from the main menu (option 9)
-2. Press `t` to toggle shuffle mode on
+2. Press `ctrl+t` to toggle shuffle mode on
 3. Enter your keyword (e.g., "jazz", "rock", "meditation")
 4. Press Enter to start shuffle mode
 

--- a/internal/ui/lucky.go
+++ b/internal/ui/lucky.go
@@ -447,8 +447,8 @@ func (m LuckyModel) updateInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	}
 
-	// Handle 't' key to toggle shuffle mode (when not typing in input)
-	if key == "t" && m.textInput.Value() == "" {
+	// Handle 'ctrl+t' key to toggle shuffle mode (when not typing in input)
+	if key == "ctrl+t" {
 		m.shuffleEnabled = !m.shuffleEnabled
 		return m, nil
 	}
@@ -1022,7 +1022,7 @@ func (m LuckyModel) viewInput() string {
 	if m.shuffleEnabled {
 		content.WriteString("Shuffle mode: ")
 		content.WriteString(highlightStyle().Render("[✓] On"))
-		content.WriteString("  (press 't' to disable)")
+		content.WriteString("  (press 'ctrl+t' to disable)")
 		if m.shuffleConfig.AutoAdvance {
 			fmt.Fprintf(&content, "\n              Auto-advance in %d min • History: %d stations",
 				m.shuffleConfig.IntervalMinutes, m.shuffleConfig.MaxHistory)
@@ -1030,7 +1030,7 @@ func (m LuckyModel) viewInput() string {
 	} else {
 		content.WriteString("Shuffle mode: ")
 		content.WriteString(infoStyle().Render("[ ] Off"))
-		content.WriteString(" (press 't' to enable)")
+		content.WriteString(" (press 'ctrl+t' to enable)")
 	}
 
 	// Show history menu if available

--- a/internal/ui/lucky_test.go
+++ b/internal/ui/lucky_test.go
@@ -574,21 +574,25 @@ func TestLuckyShuffleToggle(t *testing.T) {
 	}
 
 	// Toggle shuffle on
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("t")}
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("ctrl+t")}
 	updatedModel, _ := model.Update(msg)
 	luckyModel := updatedModel.(LuckyModel)
 
 	if !luckyModel.shuffleEnabled {
-		t.Error("Expected shuffle to be enabled after pressing 't'")
+		t.Error("Expected shuffle to be enabled after pressing 'ctrl+t'")
+	}
+
+	if luckyModel.textInput.Value() != "" {
+		t.Error("Expected input to be empty")
 	}
 
 	// Toggle shuffle off
-	msg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("t")}
+	msg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("ctrl+t")}
 	updatedModel, _ = luckyModel.Update(msg)
 	luckyModel = updatedModel.(LuckyModel)
 
 	if luckyModel.shuffleEnabled {
-		t.Error("Expected shuffle to be disabled after pressing 't' again")
+		t.Error("Expected shuffle to be disabled after pressing 'ctrl+t' again")
 	}
 }
 


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #97 

## 📑 Description
This change modifies the _Shuffle mode_ toggle hot key in the _I Feel Lucky_ menu from `t` to `ctrl+t`. This allows the user to type any value in the _Genre/keyword_ field without triggering the _Shuffle mode_ toggle when it begins with a `t`.

The alternative is to make _Shuffle mode_ a selectable text input that toggles the  `✓` off and on  when the user presses space/enter/etc. This would require more changes to allow navigating up and down the two input fields and through the list of _Recent Searches_.  Currently, up and down is exclusively for the _Recent Searches_.

However, this change is the fast and minimal amount of changes. The hotkey can be changed, preferably a `ctrl`, `meta`, or `alt` key combination to avoid erroneously toggling.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated keyboard shortcut documentation for shuffle mode throughout README files, changing the referenced shortcut from 't' to 'ctrl+t'

* **Updates**
  * Modified shuffle mode toggle keyboard shortcut from 't' to 'ctrl+t' with corresponding input handling updated to support the new keybinding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->