### PR TITLE
fix: shuffle history replace 3 hardcoded with m.shuffleConfig.MaxHistory

### DIFF
--- a/v3/internal/ui/lucky.go
+++ b/v3/internal/ui/lucky.go
@@ -1882,10 +1882,14 @@ func (m LuckyModel) viewShufflePlaying() string {
 		content.WriteString(subtitleStyle().Render("─── Shuffle History ───"))
 		content.WriteString("\n")
 
-		// Show up to 3 most recent stations
+		// Show up to MaxHistory most recent stations
+		maxDisplay := m.shuffleConfig.MaxHistory
+		if maxDisplay <= 0 {
+			maxDisplay = 3
+		}
 		startIdx := 0
-		if len(history) > 3 {
-			startIdx = len(history) - 3
+		if len(history) > maxDisplay {
+			startIdx = len(history) - maxDisplay
 		}
 
 		for i := startIdx; i < len(history); i++ {


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The shuffle history display limit is now configurable, replacing the previous hard-coded maximum of 3 items (defaults to 3 if not specified).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->